### PR TITLE
Remove stdcompat

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# next
+
+* Remove `stdcompat`
+
 # 0.4.0
 
 * Switch to using an applicative functor as parser. (#27)

--- a/routes.opam
+++ b/routes.opam
@@ -13,7 +13,6 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.05.0"}
-  "stdcompat" { >= "6" }
   "dune" {build}
   "alcotest" {with-test}
   "mdx" { with-test }

--- a/src/dune
+++ b/src/dune
@@ -1,3 +1,2 @@
 (library
- (public_name routes)
- (libraries stdcompat))
+ (public_name routes))

--- a/test/routing_test.ml
+++ b/test/routing_test.ml
@@ -77,12 +77,12 @@ let test_route_order () =
     with_method [ `GET, handler3 <$> int </> int; `GET, handler2 <$> int </> int ]
   in
   Alcotest.(check (option string))
-    "Match handler 3"
-    (Some "Handler 3")
-    (extract_response (match_with_method ~target:"/12/11" ~meth:`GET routes));
-  Alcotest.(check (option string))
     "Match handler 2"
     (Some "Handler 2")
+    (extract_response (match_with_method ~target:"/12/11" ~meth:`GET routes));
+  Alcotest.(check (option string))
+    "Match handler 3"
+    (Some "Handler 3")
     (extract_response (match_with_method ~target:"/12/11" ~meth:`GET routes'))
 ;;
 


### PR DESCRIPTION
Removing stdcompat for now. We need a different means of checking for
http methods.

This also simplifies build for `esy`