### PR TITLE
Improve mdx test rule

### DIFF
--- a/dune
+++ b/dune
@@ -1,8 +1,9 @@
 (alias
  (name runtest)
  (deps
+  (package routes)
   (:x README.md))
  (action
   (progn
-   (run ocaml-mdx test --direction=infer-timestamp %{x})
+   (run ocaml-mdx test %{x})
    (diff? %{x} %{x}.corrected))))


### PR DESCRIPTION
First of all I'm glad to see a real life user of mdx!

I took the liberty to open a PR to slightly improve the mdx invocation in your dune file as it won't survive the next mdx release!

It was using the `--direction` option which is unnecessary given that option is used for ocaml blocks synchronized with external files and there weren't any such blocks in the `README.md`.
I ran into this when trying to release `mdx.1.5.0` in which we removed the `infer-timestamp` direction as it wasn't working properly. I updated the constraints on the `mdx` dependency so that `routes.0.5.2` can still properly be installed and tested through opam. You can see the release PR over there if you want to know more: https://github.com/ocaml/opam-repository/pull/15415

We did that in a minor release because we believed it was unused outside of RealWorldOCaml but it turns out it was here! Sorry for the inconvenience!

I also added a dependency on the `routes` package so that `dune runtest` works from scratch and don't require a previous `dune build` so hopefully you'll enjoy that small improvement.

We're currently working on a future `2.0.0` release of `mdx` with proper integration to dune so that this kind of quirks don't show up again and you won't have to care too much about such CLI options.

Let me know what you think!