### PR TITLE
don't force routes to be thunks

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ val search_user : string -> string -> req -> string = <fun>
 
 # let routes = Routes.(
     one_of [
-      Some `GET, (fun () -> s "" /? nil) @--> idx
-    ; Some `GET, (fun () -> s "user" / int /? nil) @--> get_user
-    ; Some `POST, (fun () ->  s "user" / str / str /? trail) @--> search_user
+      Some `GET, (s "" /? nil) @--> idx
+    ; Some `GET, (s "user" / int /? nil) @--> get_user
+    ; Some `POST, (s "user" / str / str /? trail) @--> search_user
     ]);;
 val routes : (req -> string) Routes.router = <abstr>
 
@@ -51,10 +51,10 @@ val req : req = {target = "/user/12"}
 # match Routes.match' ~meth:`POST ~target:"/user/hello/world" routes with None -> "No match because of missing trailing slash" | Some r -> r req;;
 - : string = "No match because of missing trailing slash"
 
-# let my_fancy_route = Routes.(fun () -> s "user" / int / s "add" /? nil);;
+# let my_fancy_route () = Routes.(s "user" / int / s "add" /? nil);;
 val my_fancy_route : unit -> (int -> 'a, 'a) Routes.path = <fun>
 
-# let print_route = Routes.sprintf my_fancy_route;;
+# let print_route = Routes.sprintf @@ my_fancy_route ();;
 val print_route : int -> string = <fun>
 
 # print_route 12;;
@@ -84,13 +84,13 @@ val process_shape : shape -> string = <fun>
 # let route () = s "shape" / shape / s "create" /? nil
 val route : unit -> (shape -> '_weak3, '_weak3) path = <fun>
 
-# sprintf route
+# sprintf (route ())
 - : shape -> string = <fun>
 
-# sprintf route Square
+# sprintf (route ()) Square
 - : string = "/shape/square/create"
 
-# let router = one_of [ None, route @--> process_shape ]
+# let router = one_of [ None, route () @--> process_shape ]
 val router : string router = <abstr>
 
 # match' ~target:"/shape/circle/create" router
@@ -102,7 +102,7 @@ val router : string router = <abstr>
 # match' ~target:"/shape/triangle/create" router
 - : string option = None
 
-# Format.asprintf "%a" pp_path route
+# Format.asprintf "%a" pp_path (route ())
 - : string = "/shape/:shape/create"
 ```
 

--- a/bench/parse.ml
+++ b/bench/parse.ml
@@ -9,46 +9,46 @@ open Routes
 let routes =
   let classes () = s "1" / s "classes" / str in
   let object_routes =
-    [ (Some `POST, (fun () -> classes () /? nil) @--> fun _ -> "post class")
-    ; (Some `GET, (fun () -> classes () / int /? nil) @--> fun _ _ -> "")
-    ; (Some `PUT, (fun () -> classes () / int /? nil) @--> fun _ _ -> "")
-    ; (Some `GET, (fun () -> classes () /? nil) @--> fun _ -> "")
+    [ (Some `POST, (classes () /? nil) @--> fun _ -> "post class")
+    ; (Some `GET, (classes () / int /? nil) @--> fun _ _ -> "")
+    ; (Some `PUT, (classes () / int /? nil) @--> fun _ _ -> "")
+    ; (Some `GET, (classes () /? nil) @--> fun _ -> "")
     ]
   in
   let user_routes =
     let users () = s "1" / s "users" in
     let login () = s "1" / s "login" in
-    [ Some `POST, (fun () -> users () /? nil) @--> "Hello"
-    ; Some `GET, (fun () -> login () /? nil) @--> "login"
-    ; (Some `GET, (fun () -> users () / str /? nil) @--> fun _ -> "user")
-    ; (Some `PUT, (fun () -> users () / str /? nil) @--> fun _ -> "put user")
-    ; Some `GET, (fun () -> users () /? nil) @--> "get user"
-    ; (Some `DELETE, (fun () -> users () / str /? nil) @--> fun _ -> "delete user")
-    ; Some `POST, (fun () -> s "requestPasswordReset" /? nil) @--> "password reset"
+    [ Some `POST, (users () /? nil) @--> "Hello"
+    ; Some `GET, (login () /? nil) @--> "login"
+    ; (Some `GET, (users () / str /? nil) @--> fun _ -> "user")
+    ; (Some `PUT, (users () / str /? nil) @--> fun _ -> "put user")
+    ; Some `GET, (users () /? nil) @--> "get user"
+    ; (Some `DELETE, (users () / str /? nil) @--> fun _ -> "delete user")
+    ; Some `POST, (s "requestPasswordReset" /? nil) @--> "password reset"
     ]
   in
   let role_routes =
     let roles () = s "1" / s "roles" in
-    [ Some `POST, (fun () -> roles () /? nil) @--> "role"
-    ; (Some `GET, (fun () -> roles () / int /? nil) @--> fun _ -> "role")
-    ; (Some `PUT, (fun () -> roles () / int /? nil) @--> fun _ -> "role")
-    ; Some `GET, (fun () -> roles () /? nil) @--> "role"
-    ; (Some `DELETE, (fun () -> roles () / int /? nil) @--> fun _ -> "role")
+    [ Some `POST, (roles () /? nil) @--> "role"
+    ; (Some `GET, (roles () / int /? nil) @--> fun _ -> "role")
+    ; (Some `PUT, (roles () / int /? nil) @--> fun _ -> "role")
+    ; Some `GET, (roles () /? nil) @--> "role"
+    ; (Some `DELETE, (roles () / int /? nil) @--> fun _ -> "role")
     ]
   in
   let misc =
-    [ (Some `POST, (fun () -> s "1" / s "files" / str /? nil) @--> fun _ -> "file")
-    ; (Some `POST, (fun () -> s "1" / s "events" / str /? nil) @--> fun _ -> "event")
-    ; Some `POST, (fun () -> s "1" / s "push" /? nil) @--> "role"
-    ; Some `POST, (fun () -> s "1" / s "functions" /? nil) @--> "cloud"
+    [ (Some `POST, (s "1" / s "files" / str /? nil) @--> fun _ -> "file")
+    ; (Some `POST, (s "1" / s "events" / str /? nil) @--> fun _ -> "event")
+    ; Some `POST, (s "1" / s "push" /? nil) @--> "role"
+    ; Some `POST, (s "1" / s "functions" /? nil) @--> "cloud"
     ]
   in
   let inst_routes =
-    [ Some `POST, (fun () -> s "1" / s "installations" /? nil) @--> "install"
-    ; (Some `GET, (fun () -> s "1" / s "installations" / str /? nil) @--> fun _ -> "")
-    ; (Some `PUT, (fun () -> s "1" / s "installations" / str /? nil) @--> fun _ -> "")
-    ; Some `GET, (fun () -> s "1" / s "installations" /? nil) @--> "install"
-    ; (Some `DELETE, (fun () -> s "1" / s "installations" / str /? nil) @--> fun _ -> "")
+    [ Some `POST, (s "1" / s "installations" /? nil) @--> "install"
+    ; (Some `GET, (s "1" / s "installations" / str /? nil) @--> fun _ -> "")
+    ; (Some `PUT, (s "1" / s "installations" / str /? nil) @--> fun _ -> "")
+    ; Some `GET, (s "1" / s "installations" /? nil) @--> "install"
+    ; (Some `DELETE, (s "1" / s "installations" / str /? nil) @--> fun _ -> "")
     ]
   in
   one_of (List.concat [ object_routes; user_routes; role_routes; misc; inst_routes ])

--- a/bench/static.ml
+++ b/bench/static.ml
@@ -217,7 +217,7 @@ let router =
              let t = List.fold_left (fun acc y -> acc / x) x xs in
              t /? nil
          in
-         mr (fun () -> r))
+         mr r)
        urls)
 
 let bench_routes router targets = List.map (fun u -> match' ~target:u router) targets

--- a/example/http_server.ml
+++ b/example/http_server.ml
@@ -19,9 +19,9 @@ end
 
 let routes =
   let open Routes in
-  [ Some `GET, (fun () -> nil) @--> Handlers.hello
-  ; Some `GET, (fun () -> s "sum" / int / int /? trail) @--> Handlers.sum
-  ; Some `GET, (fun () -> s "greet" / int / str / str /? nil) @--> Handlers.greeter
+  [ Some `GET, nil @--> Handlers.hello
+  ; Some `GET, (s "sum" / int / int /? trail) @--> Handlers.sum
+  ; Some `GET, (s "greet" / int / str / str /? nil) @--> Handlers.greeter
   ]
 
 let all_route_patterns =

--- a/src/routes.ml
+++ b/src/routes.ml
@@ -135,7 +135,7 @@ type 'b router =
 
 let pattern to_ from_ label r = Conv (conv to_ from_ label, r)
 let empty_router = { method_routes = Method.M.empty; any_method = PatternTrie.empty }
-let ( @--> ) r handler = Route (r (), handler)
+let ( @--> ) r handler = Route (r, handler)
 let s w r = Match (w, r)
 let of_conv conv r = Conv (conv, r)
 let int r = of_conv (conv string_of_int int_of_string_opt ":int") r
@@ -158,8 +158,8 @@ let rec pp_path' : type a b. (a, b) path -> string list = function
   | Match (w, fmt) -> w :: pp_path' fmt
   | Conv ({ label; _ }, fmt) -> label :: pp_path' fmt
 
-let pp_path fmt r = Format.fprintf fmt "%s" ("/" ^ String.concat "/" @@ pp_path' (r ()))
-let pp_route fmt (Route (p, _)) = pp_path fmt (fun () -> p)
+let pp_path fmt r = Format.fprintf fmt "%s" ("/" ^ String.concat "/" @@ pp_path' r)
+let pp_route fmt (Route (p, _)) = pp_path fmt p
 
 let rec ksprintf' : type a b. (string list -> b) -> (a, b) path -> a =
  fun k -> function
@@ -167,7 +167,7 @@ let rec ksprintf' : type a b. (string list -> b) -> (a, b) path -> a =
   | Match (w, fmt) -> ksprintf' (fun s -> k @@ (w :: s)) fmt
   | Conv ({ to_; _ }, fmt) -> fun x -> ksprintf' (fun rest -> k @@ (to_ x :: rest)) fmt
 
-let sprintf r = ksprintf' (fun x -> "/" ^ String.concat "/" x) (r ())
+let sprintf r = ksprintf' (fun x -> "/" ^ String.concat "/" x) r
 
 let parse_route fmt handler params =
   let rec match_target : type a b. (a, b) path -> a -> string list -> b option =

--- a/src/routes.mli
+++ b/src/routes.mli
@@ -134,7 +134,7 @@ val ( /? ) : (('a, 'b) path -> 'c) -> ('a, 'b) path -> 'c
     This is used at the end of the route pattern to define how a route should end. The right hand parameter
     [r] should be a pattern definition that cannot be used in further chains joined by [/] (One such operator is [nil]). *)
 
-val ( @--> ) : (unit -> ('a, 'b) path) -> 'a -> 'b route
+val ( @--> ) : ('a, 'b) path -> 'a -> 'b route
 (** [r @--> h] is used to connect a route pattern [r] to a function [h] that gets called
     if this pattern is successfully matched.*)
 
@@ -152,11 +152,11 @@ val match' : ?meth:Method.t -> 'a router -> target:string -> 'a option
     that is not associated to any HTTP verb.
 *)
 
-val sprintf : (unit -> ('a, string) path) -> 'a
+val sprintf : ('a, string) path -> 'a
 (** [sprintf] takes a route pattern as an input, and returns a string with the result
     of formatting the pattern into a URI path. *)
 
-val pp_path : Format.formatter -> (unit -> ('a, 'b) path) -> unit
+val pp_path : Format.formatter -> ('a, 'b) path -> unit
 (** [pp_path] can be used to pretty-print a path sequence. This can be useful
     to get a human readable output that indicates the kind of pattern
     that a route will match. When creating a custom pattern matcher


### PR DESCRIPTION
Thunks are useful when trying to reuse patterns for multiple
usecases (printing, multiple routes etc). We shouldn't force users
to make every route a thunk. We should instead improve the documentation
to indicate why/where thunks will be useful.