### PR TITLE
Update bsconfig.json name

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -1,5 +1,5 @@
 {
-  "name": "routes",
+  "name": "@anuragsoni/routes",
   "sources": {
     "dir" : "src",
     "subdirs" : true


### PR DESCRIPTION
`name` should be the same in bsconfig.json and package.json (https://bucklescript.github.io/docs/en/build-configuration.html#name-namespace).
Otherwise when you use this lib with Bucklescript, it generates 
```js
var Routes = require("routes/src/routes.js");
```
which is not found since in node_modules the `routes` folder is nested inside `@anuragsoni` like set up in `package.json`, it should be
```js
var Routes = require("@anuragsoni/routes/src/routes.js");
```
which is what is generated with the correct bsconfig name.