### PR TITLE
improve trailing slash handling

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,2 +1,1 @@
 profile=janestreet
-let-binding-spacing=compact

--- a/README.md
+++ b/README.md
@@ -26,12 +26,12 @@ We will start by defining a few simple routes that don't need to extract any pat
 
 ```ocaml
 # (* A simple route that matches the empty path segments. *)
-# let root () = Routes.nil;;
-val root : unit -> ('a, 'a) Routes.path = <fun>
+# let root () = Routes.empty;;
+val root : unit -> ('a, 'a) Routes.target = <fun>
 
 # (* We can combine multiple segments using `/` *)
 # let users () = Routes.(s "users" / s "get" /? nil);;
-val users : unit -> ('a, 'a) Routes.path = <fun>
+val users : unit -> ('a, 'a) Routes.target = <fun>
 ```
 
 We can use these route definitions to pretty-print into "patterns" that can potentially be used
@@ -40,10 +40,10 @@ as a response to a route-not-found error and inform the client of what kind of r
 We will use `Format.asprintf` to get a string that contains the result of our pretty printer.
 
 ```ocaml
-# Format.asprintf "%a" Routes.pp_path (root ());;
+# Format.asprintf "%a" Routes.pp_target (root ());;
 - : string = "/"
 
-# Format.asprintf "%a" Routes.pp_path (users ());;
+# Format.asprintf "%a" Routes.pp_target (users ());;
 - : string = "/users/get"
 ```
 
@@ -53,7 +53,7 @@ path.
 
 ```ocaml
 # let sum () = Routes.(s "sum" / int / int /? nil);;
-val sum : unit -> (int -> int -> 'a, 'a) Routes.path = <fun>
+val sum : unit -> (int -> int -> 'a, 'a) Routes.target = <fun>
 ```
 
 Looking at the type for `sum` we can see that our route knows about our two integer path parameters.
@@ -61,7 +61,7 @@ A route can also extract parameters of different types.
 
 ```ocaml
 # let get_user () = Routes.(s "user" / str / int64 /? nil);;
-val get_user : unit -> (string -> int64 -> 'a, 'a) Routes.path = <fun>
+val get_user : unit -> (string -> int64 -> 'a, 'a) Routes.target = <fun>
 ```
 
 We can still pretty print such routes to get a human readable "pattern" that can be used to inform
@@ -81,10 +81,10 @@ reflect the change in the route type, and if the types change the user will get 
 types. This can be useful in ensuring that we avoid using bad/outdated URLs in our application.
 
 ```ocaml
-# Format.asprintf "%a" Routes.pp_path (sum ());;
+# Format.asprintf "%a" Routes.pp_target (sum ());;
 - : string = "/sum/:int/:int"
 
-# Format.asprintf "%a" Routes.pp_path (get_user ());;
+# Format.asprintf "%a" Routes.pp_target (get_user ());;
 - : string = "/user/:string/:int64"
 
 # Routes.sprintf (sum ());;

--- a/bench/main.ml
+++ b/bench/main.ml
@@ -4,3 +4,4 @@ open Core_bench
 let () =
   let benches = List.concat [ Static.benches; Parse.benches ] in
   Command.run @@ Bench.make_command benches
+;;

--- a/bench/parse.ml
+++ b/bench/parse.ml
@@ -50,18 +50,22 @@ let routes =
     ]
   in
   one_of (List.concat [ object_routes; user_routes; role_routes; misc; inst_routes ])
+;;
 
 open Core_bench
 
 let bench_static =
   Bench.Test.create ~name:"Parse static" (fun () -> match' ~target:"/1/users" routes)
+;;
 
 let bench_one_param =
   Bench.Test.create ~name:"Parse 1 param" (fun () ->
       match' ~target:"/1/classes/ocaml" routes)
+;;
 
 let bench_two_param =
   Bench.Test.create ~name:"Parse 2 param" (fun () ->
       match' ~target:"/1/classes/ocaml/121" routes)
+;;
 
 let benches = [ bench_static; bench_one_param; bench_two_param ]

--- a/bench/static.ml
+++ b/bench/static.ml
@@ -181,6 +181,7 @@ let urls =
   ; "/progs/timeout2.go"
   ; "/progs/update.bash"
   ]
+;;
 
 let handler = ()
 
@@ -198,6 +199,7 @@ module Util = struct
     | None -> split_target target
     | Some 0 -> []
     | Some i -> split_target (String.sub target 0 i)
+  ;;
 end
 
 open Routes
@@ -211,7 +213,7 @@ let router =
          let split = Util.split_path u |> List.map (fun q -> s q) in
          let r =
            match split with
-           | [] -> nil
+           | [] -> empty
            | [ x ] -> x /? nil
            | x :: xs ->
              let t = List.fold_left (fun acc y -> acc / y) x xs in
@@ -219,11 +221,13 @@ let router =
          in
          mr r)
        urls)
+;;
 
 let bench_routes router targets = List.map (fun u -> match' ~target:u router) targets
 
 let bench =
   let open Core_bench in
   Bench.Test.create ~name:"Static Bench" (fun () -> bench_routes router urls)
+;;
 
 let benches = [ bench ]

--- a/dune-project
+++ b/dune-project
@@ -1,3 +1,2 @@
 (lang dune 1.0)
-
 (name routes)

--- a/example/http_server.ml
+++ b/example/http_server.ml
@@ -6,12 +6,14 @@ let respond_with_text reqd status text =
     Headers.of_list [ "content-length", Int.to_string (String.length text) ]
   in
   Reqd.respond_with_string reqd (Response.create ~headers status) text
+;;
 
 module Handlers = struct
   let greeter id name city { Request.target; _ } =
     Logs.info (fun m ->
         m "Woohoo! I have access to the Httpaf request here: Id: %d %s" id target);
     "Hello, " ^ name ^ ". How was your trip to " ^ city ^ "?"
+  ;;
 
   let sum a b _ = Printf.sprintf "The sum of %d and %d = %d" a b (a + b)
   let hello _ = "Hello World"
@@ -19,10 +21,11 @@ end
 
 let routes =
   let open Routes in
-  [ nil @--> Handlers.hello
-  ; (s "sum" / int / int /? trail) @--> Handlers.sum
+  [ empty @--> Handlers.hello
+  ; (s "sum" / int / int //? nil) @--> Handlers.sum
   ; (s "greet" / int / str / str /? nil) @--> Handlers.greeter
   ]
+;;
 
 let all_route_patterns = List.map (fun r -> Format.asprintf "%a" Routes.pp_route r) routes
 
@@ -34,6 +37,7 @@ let not_found_message =
   Printf.sprintf
     "Route not found. The list of existing route patterns is:\n%s\n"
     join_routes
+;;
 
 let request_handler _ reqd =
   let ({ Request.target; _ } as req) = Reqd.request reqd in
@@ -41,6 +45,7 @@ let request_handler _ reqd =
   match Routes.match' ~target router with
   | None -> respond_with_text reqd `Not_found not_found_message
   | Some f -> respond_with_text reqd `OK (f req)
+;;
 
 let error_handler _ ?request:_ error start_response =
   let response_body = start_response Headers.empty in
@@ -51,6 +56,7 @@ let error_handler _ ?request:_ error start_response =
   | #Status.standard as error ->
     Body.write_string response_body (Status.default_reason_phrase error));
   Body.close_writer response_body
+;;
 
 let main port =
   let open Lwt.Infix in
@@ -63,6 +69,7 @@ let main port =
       >>= fun _server -> Lwt.return_unit);
   let forever, _ = Lwt.wait () in
   Lwt_main.run forever
+;;
 
 let () =
   Logs.set_level (Some Logs.Info);
@@ -73,3 +80,4 @@ let () =
     ignore
     "Routing example";
   main !port
+;;

--- a/example/no_http.ml
+++ b/example/no_http.ml
@@ -18,11 +18,13 @@ module R = struct
       ; user_and_admin @--> admin_handler
       ; q @--> "Foobar"
       ]
+  ;;
 end
 
 let unwrap_result = function
   | None -> "No match"
   | Some r -> r
+;;
 
 let () =
   let targets =
@@ -38,3 +40,4 @@ let () =
   List.iter
     (fun target -> print_endline (unwrap_result @@ Routes.match' ~target R.routes))
     targets
+;;


### PR DESCRIPTION
This should prevent construction of routes that don't
make much sense, ex: `trail @--> ...`

Changes from the previos version

* Instead of separate `nil` and `trail` we just have `nil`
* To distinguish between regular slash and trailing slash use ` /? ` vs ` //? ` (the extra slash used to indicate a trailing slash)
* `empty` can be used to create a route that matches "/" and "", instead of `nil @-->` or worse `trail @-->`