### PR TITLE
Add map and path prefixing to targets

### DIFF
--- a/src/routes.ml
+++ b/src/routes.ml
@@ -271,3 +271,5 @@ let match' routes ~target =
   let matcher = run_routes target in
   matcher routes
 ;;
+
+let ( /~ ) m { path; slash_kind } = { path = m path; slash_kind }

--- a/src/routes.ml
+++ b/src/routes.ml
@@ -135,13 +135,13 @@ type ('a, 'b) target =
   ; path : ('a, 'b) path
   }
 
-type 'b route = Route : ('a, 'b) target * 'a -> 'b route
+type 'b route = Route : ('a, 'c) target * 'a * ('c -> 'b) -> 'b route
 type 'b router = 'b route PatternTrie.t
 
 let pattern to_ from_ label r = Conv (conv to_ from_ label, r)
 let custom ~serialize:to_ ~parse:from_ ~label r = Conv (conv to_ from_ label, r)
 let empty_router = PatternTrie.empty
-let ( @--> ) r handler = Route (r, handler)
+let ( @--> ) r handler = Route (r, handler, fun x -> x)
 let s w r = Match (w, r)
 let of_conv conv r = Conv (conv, r)
 let int r = of_conv (conv string_of_int int_of_string_opt ":int") r
@@ -187,7 +187,7 @@ let pp_path' { slash_kind; path } =
 ;;
 
 let pp_target fmt t = Format.fprintf fmt "%s" ("/" ^ String.concat "/" @@ pp_path' t)
-let pp_route fmt (Route (p, _)) = pp_target fmt p
+let pp_route fmt (Route (p, _, _)) = pp_target fmt p
 
 let ksprintf' k { slash_kind; path } =
   let trail =
@@ -237,7 +237,7 @@ let parse_route { slash_kind; path } handler params =
 let one_of routes =
   let routes = List.rev routes in
   List.fold_left
-    (fun routes (Route ({ path; _ }, _) as route) ->
+    (fun routes (Route ({ path; _ }, _, _) as route) ->
       let patterns = route_pattern path in
       PatternTrie.add patterns route routes)
     empty_router
@@ -247,7 +247,7 @@ let one_of routes =
 let union = PatternTrie.union
 
 let add_route route routes =
-  let (Route ({ path; _ }, _)) = route in
+  let (Route ({ path; _ }, _, _)) = route in
   let patterns = route_pattern path in
   PatternTrie.add patterns route routes
 ;;
@@ -256,13 +256,15 @@ let run_routes target router =
   let routes = PatternTrie.feed_params router target in
   let rec aux = function
     | [] -> None
-    | Route (r, h) :: rs ->
+    | Route (r, h, f) :: rs ->
       (match parse_route r h target with
       | None -> aux rs
-      | Some r -> Some r)
+      | Some r -> Some (f r))
   in
   aux routes
 ;;
+
+let map f (Route (r, h, g)) = Route (r, h, fun x -> f (g x))
 
 let match' routes ~target =
   let target = Util.split_path target in

--- a/src/routes.mli
+++ b/src/routes.mli
@@ -150,6 +150,8 @@ val custom
     ]} *)
 val ( / ) : (('a, 'b) path -> 'c) -> ('d -> ('a, 'b) path) -> 'd -> 'c
 
+val ( /~ ) : (('a, 'b) path -> ('c, 'd) path) -> ('a, 'b) target -> ('c, 'd) target
+
 (** [l /? r] is used to express the sequence of, parse l followed by parse r and then stop parsing.
     This is used at the end of the route pattern to define how a route should end. The right hand parameter
     [r] should be a pattern definition that cannot be used in further chains joined by [/].

--- a/src/routes.mli
+++ b/src/routes.mli
@@ -174,6 +174,8 @@ val ( @--> ) : ('a, 'b) target -> 'a -> 'b route
     to perform route matches. *)
 val one_of : 'b route list -> 'b router
 
+val map : ('a -> 'b) -> 'a route -> 'b route
+
 (** [match'] accepts a router and the target url to match. *)
 val match' : 'a router -> target:string -> 'a option
 


### PR DESCRIPTION
Hi again!

We're making heavy use of this library, and these additions would help us, if you think they make sense (happy to think again about the choice of "/~" as an operator name).