### PR TITLE
Add ksprintf.

### DIFF
--- a/src/routes.ml
+++ b/src/routes.ml
@@ -205,7 +205,8 @@ let ksprintf' k { slash_kind; path } =
   aux k path
 ;;
 
-let sprintf t = ksprintf' (fun x -> "/" ^ String.concat "/" x) t
+let ksprintf k t = ksprintf' (fun x -> k ("/" ^ String.concat "/" x)) t
+let sprintf t = ksprintf (fun x -> x) t
 
 let parse_route { slash_kind; path } handler params =
   let rec match_target : type a b. (a, b) path -> a -> string list -> b option =

--- a/src/routes.mli
+++ b/src/routes.mli
@@ -181,6 +181,10 @@ val map : ('a -> 'b) -> 'a route -> 'b route
 (** [match'] accepts a router and the target url to match. *)
 val match' : 'a router -> target:string -> 'a option
 
+(** [ksprintf] takes a route pattern as an input and applies a continuation to
+   the result of formatting the pattern into a URI path. *)
+val ksprintf : (string -> 'b) -> ('a, 'b) target -> 'a
+
 (** [sprintf] takes a route pattern as an input, and returns a string with the result
     of formatting the pattern into a URI path. *)
 val sprintf : ('a, string) target -> 'a


### PR DESCRIPTION
Hi again @anuragsoni.

I'm PRing this really just to get your take on this function. For context, I'm wanting to use `sprintf` to create internal urls to routes we serve, but it seems to be difficult to use these at the moment. For example, I would like to have a function which takes a target, and turns it into a complete url with the protocol and domain name, but I'm struggling to write this function. And going further, I'd like to have a function which takes a target, and automatically performs an internal get request. So I think I want a function like

```
internal_get : ('a, response) target -> 'a
```

where, at the use site, `'a` will be something like `int -> string -> response`.

With `ksprintf`, I could write

```
let target = Routes.(s "foo" / int / s "bar" / str /? nil) 
in Routes.ksprintf (fun str -> do_get (Printf.sprintf "https://example.com%s" str)) foo

- : int -> string -> string = <fun>
```

Is there another way to achieve this, or arguments against it?