### PR TITLE
turn off publishing to npm

### DIFF
--- a/.github/workflows/publish_bucklescript.yml
+++ b/.github/workflows/publish_bucklescript.yml
@@ -10,14 +10,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
-          registry-url: 'https://registry.npmjs.org'
-      - run: npm install
-      - run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - uses: actions/setup-node@v1
-        with:
           registry-url: 'https://npm.pkg.github.com'
       - run: npm publish
         env:


### PR DESCRIPTION
The npm package isn't used by anyone (npm shows under 10 downloads over the past few weeks). The publishing is also broken at the moment. I don't know much about the npm/bucklescript ecosystem so turning this off seems like the way forward at the moment. The package can still be published to the github npm registry.