### PR TITLE
Change trailing slash handling

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,13 +14,11 @@ jobs:
         operating-system:
           - ubuntu-latest
         ocaml-version:
-          - 4.12.x
-          - 4.11.x
-          - 4.07.x
-          - 4.05.x
+          - 4.13.x
+          - 4.08.x
         include:
           - operating-system: windows-latest
-            ocaml-version: 4.12.x
+            ocaml-version: 4.13.x
     steps:
       - uses: actions/checkout@v2
       - name: Setup OCaml ${{ matrix.ocaml-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,9 +16,6 @@ jobs:
         ocaml-version:
           - 4.13.x
           - 4.08.x
-        include:
-          - operating-system: windows-latest
-            ocaml-version: 4.13.x
     steps:
       - uses: actions/checkout@v2
       - name: Setup OCaml ${{ matrix.ocaml-version }}
@@ -31,14 +28,9 @@ jobs:
         run: |
           opam pin add routes.dev -n .
           opam install -t . --deps-only
-      - name: Build
-        run: |
-          opam exec -- dune build @install
       - name: Run tests
-        if: runner.os == 'Linux'
         run: |
           opam exec -- dune runtest
-      - name: Run doctest
-        if: runner.os == 'Linux'
+      - name: Build examples
         run: |
           opam exec -- dune build @example

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,11 @@ jobs:
         run: |
           opam pin add routes.dev -n .
           opam install -t . --deps-only
+      - name: Build
+        run: |
+          opam exec -- dune build @install
       - name: Run tests
+        if: runner.os == 'Linux'
         run: |
           opam exec -- dune runtest
       - name: Run doctest

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,15 @@
+# 2.0.0
+
+* use `ppx_expect` for tests
+
+## Breaking changes
+
+* Drop support for OCaml 4.05-4.07
+* Switch to a new model for trailing slash handling. In routes 1.0.0 users needed to be careful about using `/?` and `//?` as the former would only match routes without a trailing slash, and the latter would enforce a trailing slash.
+  - Users only need to use `/?` or `//?` to end routes, and it will cover both routes ending with trailing slashes and without
+  - The type used for representing match results has more information about whether it was an exact match, a match where the only difference is the presence or absence of a trailing slash, or if there is no match.
+  - The information about trailing slashes in the match response can be used to either redirect the user to a different page, or use the returned handler if the app doesn't want to differentiate between routes with trailing slashes and without.
+
 # 1.0.0
 
 * First major release. No changes from 0.9.1

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,9 +6,9 @@
 
 * Drop support for OCaml 4.05-4.07
 * Switch to a new model for trailing slash handling. In routes 1.0.0 users needed to be careful about using `/?` and `//?` as the former would only match routes without a trailing slash, and the latter would enforce a trailing slash.
-  - Users only need to use `/?` or `//?` to end routes, and it will cover both routes ending with trailing slashes and without
-  - The type used for representing match results has more information about whether it was an exact match, a match where the only difference is the presence or absence of a trailing slash, or if there is no match.
-  - The information about trailing slashes in the match response can be used to either redirect the user to a different page, or use the returned handler if the app doesn't want to differentiate between routes with trailing slashes and without.
+  - Users only need to use `/?` to end routes, and it will cover both routes ending with trailing slashes and without
+  - The type used for representing match results has more information about whether it was an exact match, or if it was a match but the input target had a trailing slash at the end.
+  - `MatchWithTrailingSlash` informs the user that the current target was considered a match, but that the target has an additional trailing slash
 
 # 1.0.0
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ val routes : string Routes.router = <abstr>
 
 # (* This route is not an exact match because of the final trailing slash. *);;
 # Routes.match' routes ~target:"/sum/1/2/";;
-- : string Routes.match_result = Routes.MatchWithoutTrailingSlash "3"
+- : string Routes.match_result = Routes.MatchWithTrailingSlash "3"
 ```
 
 #### Dealing with trailing slashes
@@ -162,7 +162,7 @@ val no_trail : unit -> int Routes.route = <fun>
 - : int Routes.match_result = Routes.FullMatch 5
 
 # Routes.(match' (one_of [ no_trail () ]) ~target:"/foo/bar/hello/");;
-- : int Routes.match_result = Routes.MatchWithoutTrailingSlash 5
+- : int Routes.match_result = Routes.MatchWithTrailingSlash 5
 ```
 
 To create a route that returns an exact match if there is a trailing slash, the route still needs to
@@ -176,7 +176,7 @@ val trail : unit -> int Routes.route = <fun>
 - : int Routes.match_result = Routes.FullMatch 5
 
 # Routes.(match' (one_of [ trail () ]) ~target:"/foo/bar/hello/");;
-- : int Routes.match_result = Routes.MatchWithoutTrailingSlash 5
+- : int Routes.match_result = Routes.MatchWithTrailingSlash 5
 ```
 
 More example of library usage can be seen in the [examples](https://github.com/anuragsoni/routes/tree/main/example) folder,

--- a/README.md
+++ b/README.md
@@ -129,40 +129,45 @@ attached to every route in a router should have the same type for the values the
 val routes : string Routes.router = <abstr>
 
 # Routes.match' routes ~target:"/";;
-- : string option = Some "Hello World"
+- : string Routes.match_result = Routes.FullMatch "Hello World"
 
 # Routes.match' routes ~target:"/sum/25/11";;
-- : string option = Some "36"
+- : string Routes.match_result = Routes.FullMatch "36"
 
 # Routes.match' routes ~target:"/user/John/1251";;
-- : string option = Some "(1251) John"
+- : string Routes.match_result = Routes.FullMatch "(1251) John"
 
 # Routes.match' routes ~target:(Routes.sprintf (sum ()) 45 11);;
-- : string option = Some "56"
+- : string Routes.match_result = Routes.FullMatch "56"
 
-# (* This route fails to match because of the final trailing slash. *);;
+# (* This route is not an exact match because of the final trailing slash. *);;
 # Routes.match' routes ~target:"/sum/1/2/";;
-- : string option = None
+- : string Routes.match_result =
+Routes.Match {Routes.with_trailing_slash = false; result = "3"}
 ```
 
 #### Dealing with trailing slashes
 
 Every route definition can control what behavior it expects when it encounters
 a trailing slash. In the examples above all route definitions ended with
-`/? nil`. This will result in a successful match if the route does not end in a trailing slash.
+`/? nil`. This will result in an exact match if the route does not end in a trailing slash.
+If the input target matches every paramter but has an additional trailing slash, the route will
+still be considered a match, but it will inform the user that the matching route was found because of
+disregarding the trailing slash.
 
 ```ocaml
 # let no_trail () = Routes.(s "foo" / s "bar" / str /? nil @--> fun msg -> String.length msg);;
 val no_trail : unit -> int Routes.route = <fun>
 
 # Routes.(match' (one_of [ no_trail () ]) ~target:"/foo/bar/hello");;
-- : int option = Some 5
+- : int Routes.match_result = Routes.FullMatch 5
 
 # Routes.(match' (one_of [ no_trail () ]) ~target:"/foo/bar/hello/");;
-- : int option = None
+- : int Routes.match_result =
+Routes.Match {Routes.with_trailing_slash = false; result = 5}
 ```
 
-To create a route that returns a success if there is a trailing slash, the route still needs to
+To create a route that returns an exact match if there is a trailing slash, the route still needs to
 end with `nil`, but instead of `/?`, `//?` needs to be used. (note the extra slash).
 
 ```ocaml
@@ -170,10 +175,11 @@ end with `nil`, but instead of `/?`, `//?` needs to be used. (note the extra sla
 val trail : unit -> int Routes.route = <fun>
 
 # Routes.(match' (one_of [ trail () ]) ~target:"/foo/bar/hello");;
-- : int option = None
+- : int Routes.match_result =
+Routes.Match {Routes.with_trailing_slash = true; result = 5}
 
 # Routes.(match' (one_of [ trail () ]) ~target:"/foo/bar/hello/");;
-- : int option = Some 5
+- : int Routes.match_result = Routes.FullMatch 5
 ```
 
 More example of library usage can be seen in the [examples](https://github.com/anuragsoni/routes/tree/main/example) folder,

--- a/bench/static.ml
+++ b/bench/static.ml
@@ -207,7 +207,7 @@ let router =
          let split = Util.split_path u |> List.map (fun q -> s q) in
          let r =
            match split with
-           | [] -> empty
+           | [] -> nil
            | [ x ] -> x /? nil
            | x :: xs ->
              let t = List.fold_left (fun acc y -> acc / y) x xs in

--- a/dune
+++ b/dune
@@ -1,5 +1,5 @@
-; (mdx
-;  (files README.md)
-;  (enabled_if
-;   (= %{os_type} Unix))
-;  (packages routes))
+(mdx
+ (files README.md)
+ (enabled_if
+  (= %{os_type} Unix))
+ (packages routes))

--- a/dune
+++ b/dune
@@ -1,5 +1,5 @@
-(mdx
- (files README.md)
- (enabled_if
-  (= %{os_type} Unix))
- (packages routes))
+; (mdx
+;  (files README.md)
+;  (enabled_if
+;   (= %{os_type} Unix))
+;  (packages routes))

--- a/dune
+++ b/dune
@@ -1,5 +1,3 @@
 (mdx
  (files README.md)
- (enabled_if
-  (= %{os_type} Unix))
  (packages routes))

--- a/dune-project
+++ b/dune-project
@@ -23,8 +23,13 @@
   (router http))
  (depends
   (ocaml
-   (>= 4.05.0))
-  (alcotest :with-test)
+   (>= 4.08.0))
+  (base :with-test)
+  (stdio :with-test)
+  (ppx_expect :with-test)
+  (ppx_sexp_conv :with-test)
+  (ppx_sexp_value :with-test)
+  (ppx_custom_printf :with-test)
   (mdx :with-test)
   (odoc :with-doc))
  (synopsis "Typed routing for OCaml applications")

--- a/example/no_http.ml
+++ b/example/no_http.ml
@@ -22,8 +22,9 @@ module R = struct
 end
 
 let unwrap_result = function
-  | None -> "No match"
-  | Some r -> r
+  | Routes.NotFound -> "No match"
+  | FullMatch r -> r
+  | Match { result; _ } -> result
 ;;
 
 let () =

--- a/example/no_http.ml
+++ b/example/no_http.ml
@@ -24,7 +24,7 @@ end
 let unwrap_result = function
   | Routes.NoMatch -> "No match"
   | FullMatch r -> r
-  | MatchWithoutTrailingSlash r -> r
+  | MatchWithTrailingSlash r -> r
 ;;
 
 let () =

--- a/example/no_http.ml
+++ b/example/no_http.ml
@@ -22,9 +22,9 @@ module R = struct
 end
 
 let unwrap_result = function
-  | Routes.NotFound -> "No match"
+  | Routes.NoMatch -> "No match"
   | FullMatch r -> r
-  | Match { result; _ } -> result
+  | MatchWithoutTrailingSlash r -> r
 ;;
 
 let () =

--- a/routes.opam
+++ b/routes.opam
@@ -12,8 +12,13 @@ doc: "https://anuragsoni.github.io/routes/"
 bug-reports: "https://github.com/anuragsoni/routes/issues"
 depends: [
   "dune" {>= "2.9"}
-  "ocaml" {>= "4.05.0"}
-  "alcotest" {with-test}
+  "ocaml" {>= "4.08.0"}
+  "base" {with-test}
+  "stdio" {with-test}
+  "ppx_expect" {with-test}
+  "ppx_sexp_conv" {with-test}
+  "ppx_sexp_value" {with-test}
+  "ppx_custom_printf" {with-test}
   "mdx" {with-test}
   "odoc" {with-doc}
 ]

--- a/src/routes.ml
+++ b/src/routes.ml
@@ -193,7 +193,7 @@ let sprintf t = ksprintf (fun x -> x) t
 
 type 'a match_result =
   | FullMatch of 'a
-  | MatchWithoutTrailingSlash of 'a
+  | MatchWithTrailingSlash of 'a
   | NoMatch
 
 let parse_route path handler params =
@@ -204,7 +204,7 @@ let parse_route path handler params =
     match t with
     | End ->
       (match s with
-      | [ "" ] -> MatchWithoutTrailingSlash f
+      | [ "" ] -> MatchWithTrailingSlash f
       | [] -> FullMatch f
       | _ -> NoMatch)
     | Wildcard -> FullMatch (f { Parts.prefix = List.rev seen; matched = s })
@@ -249,7 +249,7 @@ let run_routes target router =
       (match parse_route r h target with
       | NoMatch -> aux rs
       | FullMatch r -> FullMatch (f r)
-      | MatchWithoutTrailingSlash r -> MatchWithoutTrailingSlash (f r))
+      | MatchWithTrailingSlash r -> MatchWithTrailingSlash (f r))
   in
   aux routes
 ;;

--- a/src/routes.ml
+++ b/src/routes.ml
@@ -138,16 +138,7 @@ type ('a, 'b) path =
   | Match : string * ('a, 'b) path -> ('a, 'b) path
   | Conv : 'c conv * ('a, 'b) path -> ('c -> 'a, 'b) path
 
-type slash_kind =
-  | Trailing
-  | NoSlash
-
-type ('a, 'b) target =
-  { slash_kind : slash_kind
-  ; path : ('a, 'b) path
-  }
-
-type 'b route = Route : ('a, 'c) target * 'a * ('c -> 'b) -> 'b route
+type 'b route = Route : ('a, 'c) path * 'a * ('c -> 'b) -> 'b route
 type 'b router = 'b route PatternTrie.t
 
 let pattern to_ from_ label r = Conv (conv to_ from_ label, r)
@@ -164,17 +155,7 @@ let bool r = of_conv (conv string_of_bool bool_of_string_opt ":bool") r
 let wildcard = Wildcard
 let ( / ) m1 m2 r = m1 @@ m2 r
 let nil = End
-let empty = { slash_kind = NoSlash; path = End }
-
-let ( /? ) m1 m2 =
-  let path = m1 m2 in
-  { slash_kind = NoSlash; path }
-;;
-
-let ( //? ) m1 m2 =
-  let path = m1 m2 in
-  { slash_kind = Trailing; path }
-;;
+let ( /? ) m1 m2 = m1 m2
 
 let rec route_pattern : type a b. (a, b) path -> PatternTrie.Key.t list = function
   | End -> []
@@ -183,14 +164,9 @@ let rec route_pattern : type a b. (a, b) path -> PatternTrie.Key.t list = functi
   | Conv (_, fmt) -> PatternTrie.Key.Capture :: route_pattern fmt
 ;;
 
-let pp_path' { slash_kind; path } =
-  let trail =
-    match slash_kind with
-    | NoSlash -> []
-    | Trailing -> [ "" ]
-  in
+let pp_path' path =
   let rec aux : type a b. (a, b) path -> string list = function
-    | End -> trail
+    | End -> []
     | Wildcard -> [ ":wildcard" ]
     | Match (w, fmt) -> w :: aux fmt
     | Conv ({ label; _ }, fmt) -> label :: aux fmt
@@ -201,16 +177,11 @@ let pp_path' { slash_kind; path } =
 let pp_target fmt t = Format.fprintf fmt "%s" ("/" ^ String.concat "/" @@ pp_path' t)
 let pp_route fmt (Route (p, _, _)) = pp_target fmt p
 
-let ksprintf' k { slash_kind; path } =
-  let trail =
-    match slash_kind with
-    | NoSlash -> []
-    | Trailing -> [ "" ]
-  in
+let ksprintf' k path =
   let rec aux : type a b. (string list -> b) -> (a, b) path -> a =
    fun k -> function
-    | End -> k trail
-    | Wildcard -> fun { Parts.matched; _ } -> k (List.concat [ matched; trail ])
+    | End -> k []
+    | Wildcard -> fun { Parts.matched; _ } -> k (List.concat [ matched; [] ])
     | Match (w, fmt) -> aux (fun s -> k @@ (w :: s)) fmt
     | Conv ({ to_; _ }, fmt) -> fun x -> aux (fun rest -> k @@ (to_ x :: rest)) fmt
   in
@@ -222,36 +193,31 @@ let sprintf t = ksprintf (fun x -> x) t
 
 type 'a match_result =
   | FullMatch of 'a
-  | Match of
-      { with_trailing_slash : bool
-      ; result : 'a
-      }
-  | NotFound
+  | MatchWithoutTrailingSlash of 'a
+  | NoMatch
 
-let parse_route { slash_kind; path } handler params =
+let parse_route path handler params =
   let rec match_target
       : type a b. (a, b) path -> a -> string list -> string list -> b match_result
     =
    fun t f seen s ->
     match t with
     | End ->
-      (match s, slash_kind with
-      | [ "" ], Trailing -> FullMatch f
-      | [ "" ], NoSlash -> Match { result = f; with_trailing_slash = false }
-      | [], NoSlash -> FullMatch f
-      | [], Trailing -> Match { result = f; with_trailing_slash = true }
-      | _ -> NotFound)
+      (match s with
+      | [ "" ] -> MatchWithoutTrailingSlash f
+      | [] -> FullMatch f
+      | _ -> NoMatch)
     | Wildcard -> FullMatch (f { Parts.prefix = List.rev seen; matched = s })
     | Match (x, fmt) ->
       (match s with
       | x' :: xs when x = x' -> match_target fmt f (x' :: seen) xs
-      | _ -> NotFound)
+      | _ -> NoMatch)
     | Conv ({ from_; _ }, fmt) ->
       (match s with
-      | [] -> NotFound
+      | [] -> NoMatch
       | x :: xs ->
         (match from_ x with
-        | None -> NotFound
+        | None -> NoMatch
         | Some x' -> match_target fmt (f x') (x :: seen) xs))
   in
   match_target path handler [] params
@@ -260,7 +226,7 @@ let parse_route { slash_kind; path } handler params =
 let one_of routes =
   let routes = List.rev routes in
   List.fold_left
-    (fun routes (Route ({ path; _ }, _, _) as route) ->
+    (fun routes (Route (path, _, _) as route) ->
       let patterns = route_pattern path in
       PatternTrie.add patterns route routes)
     empty_router
@@ -270,7 +236,7 @@ let one_of routes =
 let union = PatternTrie.union
 
 let add_route route routes =
-  let (Route ({ path; _ }, _, _)) = route in
+  let (Route (path, _, _)) = route in
   let patterns = route_pattern path in
   PatternTrie.add patterns route routes
 ;;
@@ -278,13 +244,12 @@ let add_route route routes =
 let run_routes target router =
   let routes = PatternTrie.feed_params router target in
   let rec aux = function
-    | [] -> NotFound
+    | [] -> NoMatch
     | Route (r, h, f) :: rs ->
       (match parse_route r h target with
-      | NotFound -> aux rs
+      | NoMatch -> aux rs
       | FullMatch r -> FullMatch (f r)
-      | Match { with_trailing_slash; result } ->
-        Match { with_trailing_slash; result = f result })
+      | MatchWithoutTrailingSlash r -> MatchWithoutTrailingSlash (f r))
   in
   aux routes
 ;;
@@ -297,4 +262,4 @@ let match' routes ~target =
   matcher routes
 ;;
 
-let ( /~ ) m { path; slash_kind } = { path = m path; slash_kind }
+let ( /~ ) m path = m path

--- a/src/routes.mli
+++ b/src/routes.mli
@@ -189,8 +189,16 @@ val one_of : 'b route list -> 'b router
 
 val map : ('a -> 'b) -> 'a route -> 'b route
 
+type 'a match_result =
+  | FullMatch of 'a
+  | Match of
+      { with_trailing_slash : bool
+      ; result : 'a
+      }
+  | NotFound
+
 (** [match'] accepts a router and the target url to match. *)
-val match' : 'a router -> target:string -> 'a option
+val match' : 'a router -> target:string -> 'a match_result
 
 (** [ksprintf] takes a route pattern as an input and applies a continuation to the result
     of formatting the pattern into a URI path. *)

--- a/src/routes.mli
+++ b/src/routes.mli
@@ -5,13 +5,6 @@
 (** [path] represents a sequence of path parameter patterns that are expected in a route. *)
 type ('a, 'b) path
 
-(** [target] represents a combination of a sequence of path params, and whether that
-    sequence should consider trailing slash parameters or not. Its analogous to a URI
-    target.
-
-    @since 0.8.0 *)
-type ('a, 'b) target
-
 (** [route] is a combination of a path sequence, with a function that will be called on a
     successful match. When a path sequence matches, the patterns that are extracted are
     forwarded to said function with the types that the user defined. Note that because of
@@ -69,14 +62,9 @@ val s : string -> ('a, 'b) path -> ('a, 'b) path
 (** [wildcard] matches all remaining path segments as a string. *)
 val wildcard : (Parts.t -> 'a, 'a) path
 
-(** [nil] is used to end a sequence of path parameters. *)
+(** [nil] is used to end a sequence of path parameters. It can also be used to represent
+    an empty route that can match "/" or "". *)
 val nil : ('a, 'a) path
-
-(** [empty] is used to represent an empty route. This is useful for matching a route that
-    equals "/" or "".
-
-    @since 0.8.0 *)
-val empty : ('a, 'a) target
 
 (** [pattern] accepts two functions, one for converting a user provided type to a string
     representation, and another to potentially convert a string to the said type. With
@@ -160,25 +148,17 @@ val custom
     {[ let route () = Routes.(str / s "foo" / int /? nil) ]} *)
 val ( / ) : (('a, 'b) path -> 'c) -> ('d -> ('a, 'b) path) -> 'd -> 'c
 
-val ( /~ ) : (('a, 'b) path -> ('c, 'd) path) -> ('a, 'b) target -> ('c, 'd) target
+val ( /~ ) : (('a, 'b) path -> ('c, 'd) path) -> ('a, 'b) path -> ('c, 'd) path
 
 (** [l /? r] is used to express the sequence of, parse l followed by parse r and then stop
     parsing. This is used at the end of the route pattern to define how a route should
     end. The right hand parameter [r] should be a pattern definition that cannot be used
-    in further chains joined by [/].
-
-    [/?] also indicates that a route needs to finish without a trailing slash. *)
-val ( /? ) : ('a -> ('b, 'c) path) -> 'a -> ('b, 'c) target
-
-(** [//?] is similar to [/?] with the difference that it is used to create a route that
-    must finish with a trailing slash.
-
-    @since 0.8.0 *)
-val ( //? ) : ('a -> ('b, 'c) path) -> 'a -> ('b, 'c) target
+    in further chains joined by [/]. *)
+val ( /? ) : ('a -> ('b, 'c) path) -> 'a -> ('b, 'c) path
 
 (** [r @--> h] is used to connect a route pattern [r] to a function [h] that gets called
     if this pattern is successfully matched.*)
-val ( @--> ) : ('a, 'b) target -> 'a -> 'b route
+val ( @--> ) : ('a, 'b) path -> 'a -> 'b route
 
 (** [one_of] accepts a list of tuples comprised of route definitions of type ['b route]
     where 'b is the type that a successful route match will return.
@@ -191,22 +171,19 @@ val map : ('a -> 'b) -> 'a route -> 'b route
 
 type 'a match_result =
   | FullMatch of 'a
-  | Match of
-      { with_trailing_slash : bool
-      ; result : 'a
-      }
-  | NotFound
+  | MatchWithoutTrailingSlash of 'a
+  | NoMatch
 
 (** [match'] accepts a router and the target url to match. *)
 val match' : 'a router -> target:string -> 'a match_result
 
 (** [ksprintf] takes a route pattern as an input and applies a continuation to the result
     of formatting the pattern into a URI path. *)
-val ksprintf : (string -> 'b) -> ('a, 'b) target -> 'a
+val ksprintf : (string -> 'b) -> ('a, 'b) path -> 'a
 
 (** [sprintf] takes a route pattern as an input, and returns a string with the result of
     formatting the pattern into a URI path. *)
-val sprintf : ('a, string) target -> 'a
+val sprintf : ('a, string) path -> 'a
 
 (** [pp_target] can be used to pretty-print a sequence of path params. This can be useful
     to get a human readable output that indicates the kind of pattern that a route will
@@ -221,7 +198,7 @@ val sprintf : ('a, string) target -> 'a
       -: "foo/:int/add/:bool"
     ]}
     @since 0.8.0 *)
-val pp_target : Format.formatter -> ('a, 'b) target -> unit
+val pp_target : Format.formatter -> ('a, 'b) path -> unit
 
 (** [pp_route] is similar to [pp_target], except it takes a route (combination of path
     sequence and a handler) as input, instead of just a path sequence. *)

--- a/src/routes.mli
+++ b/src/routes.mli
@@ -171,7 +171,7 @@ val map : ('a -> 'b) -> 'a route -> 'b route
 
 type 'a match_result =
   | FullMatch of 'a
-  | MatchWithoutTrailingSlash of 'a
+  | MatchWithTrailingSlash of 'a
   | NoMatch
 
 (** [match'] accepts a router and the target url to match. *)

--- a/test/dune
+++ b/test/dune
@@ -1,4 +1,5 @@
-(test
+(library
  (name routing_test)
- (modules routing_test)
- (libraries alcotest routes))
+ (inline_tests)
+ (preprocess (pps ppx_expect ppx_sexp_conv ppx_sexp_value ppx_custom_printf))
+ (libraries base stdio routes))

--- a/test/dune
+++ b/test/dune
@@ -1,5 +1,6 @@
 (library
  (name routing_test)
  (inline_tests)
- (preprocess (pps ppx_expect ppx_sexp_conv ppx_sexp_value ppx_custom_printf))
+ (preprocess
+  (pps ppx_expect ppx_sexp_conv ppx_sexp_value ppx_custom_printf))
  (libraries base stdio routes))

--- a/test/routing_test.ml
+++ b/test/routing_test.ml
@@ -13,9 +13,9 @@ let ensure_string_match ~target router =
   match match' ~target router with
   | Routes.NoMatch -> printf "%s\n" "No route matched"
   | FullMatch r -> printf "Exact match with result = %s\n" r
-  | MatchWithoutTrailingSlash r ->
+  | MatchWithTrailingSlash r ->
     printf
-      "Not exact match, but found a match without a trailing slash with result = %s\n"
+      "Not exact match, but found a matching route with a trailing slash with result = %s\n"
       r
 ;;
 
@@ -24,10 +24,11 @@ let ensure_string_match' ~target router =
   match match' ~target router with
   | Routes.NoMatch -> None
   | FullMatch r -> Some (Printf.sprintf "Exact match with result = %s" r)
-  | MatchWithoutTrailingSlash r ->
+  | MatchWithTrailingSlash r ->
     Some
       (Printf.sprintf
-         "Not exact match, but found a match without a trailing slash with result = %s"
+         "Not exact match, but found a matching route with a trailing slash with result \
+          = %s"
          r)
 ;;
 
@@ -116,13 +117,13 @@ let%expect_test "test map" =
       ~f:Int.to_string
       (match match' (one_of [ route ]) ~target:"foo/5" with
       | FullMatch x -> Some x
-      | MatchWithoutTrailingSlash r -> Some r
+      | MatchWithTrailingSlash r -> Some r
       | NoMatch -> None)
   in
   let route_map =
     match match' (one_of [ map Int.to_string route ]) ~target:"foo/5" with
     | Routes.FullMatch x -> Some x
-    | MatchWithoutTrailingSlash r -> Some r
+    | MatchWithTrailingSlash r -> Some r
     | NoMatch -> None
   in
   printf
@@ -238,7 +239,7 @@ let%expect_test "match routes with a common prefix" =
     (("Matches empty route" ("Exact match with result = root"))
      ("Matches first overlapping path param" ("Exact match with result = two"))
      ("Matches first overlapping path param"
-      ("Not exact match, but found a match without a trailing slash with result = one"))
+      ("Not exact match, but found a matching route with a trailing slash with result = one"))
      ("Matches first overlapping path param" ("Exact match with result = one"))) |}]
 ;;
 

--- a/test/routing_test.ml
+++ b/test/routing_test.ml
@@ -1,99 +1,138 @@
-let test_no_match () =
+open! Base
+open! Stdio
+
+let ensure_empty ~target ~msg router =
   let open Routes in
-  Alcotest.(check (option string))
-    "Empty router has no match"
-    None
-    (match' ~target:"/foo/bar" (one_of []));
-  Alcotest.(check (option string))
-    "Empty router has no match for empty target"
-    None
-    (match' ~target:"" (one_of []))
+  match match' ~target router with
+  | Routes.NotFound -> print_endline msg
+  | _ -> assert false
 ;;
 
-let test_add_route () =
+let ensure_string_match ~target router =
+  let open Routes in
+  match match' ~target router with
+  | Routes.NotFound -> print_endline "No route matched"
+  | FullMatch r -> printf "Exact match with result = %s" r
+  | Match { with_trailing_slash; result } ->
+    printf
+      "Not exact match, but found a match %s a trailing slash with result = %s"
+      (if with_trailing_slash then "with" else "without")
+      result
+;;
+
+let ensure_string_match' ~target router =
+  let open Routes in
+  match match' ~target router with
+  | Routes.NotFound -> None
+  | FullMatch r -> Some (Printf.sprintf "Exact match with result = %s" r)
+  | Match { with_trailing_slash; result } ->
+    Some
+      (Printf.sprintf
+         "Not exact match, but found a match %s a trailing slash with result = %s"
+         (if with_trailing_slash then "with" else "without")
+         result)
+;;
+
+let%expect_test "test no match" =
   let open Routes in
   let router = one_of [] in
-  Alcotest.(check (option string))
-    "Empty router has no match"
-    None
-    (match' ~target:"/foo/bar" router);
-  Alcotest.(check (option string))
-    "Can add a route"
-    (Some "bar")
-    (match'
-       ~target:"/foo/bar"
-       (add_route ((s "foo" / str /? nil) @--> fun a -> a) router));
+  ensure_empty ~target:"/foo/bar" ~msg:"No route matched" router;
+  [%expect {| No route matched |}];
+  ensure_empty ~target:"" ~msg:"Empty router has no match for empty target" router;
+  [%expect {| Empty router has no match for empty target |}]
+;;
+
+let%expect_test "test add route" =
+  let open Routes in
+  let router = one_of [] in
+  ensure_empty ~target:"/foo/bar" ~msg:"Empty router has no match" router;
+  [%expect {| Empty router has no match |}];
+  let router = add_route ((s "foo" / str /? nil) @--> fun a -> a) router in
+  ensure_string_match ~target:"/foo/bar" router;
+  [%expect {| Exact match with result = bar |}];
   let router =
     List.fold_left
-      (fun acc r -> add_route r acc)
-      (Routes.one_of [])
+      ~f:(fun acc r -> add_route r acc)
+      ~init:(one_of [])
       [ ((s "user" / str / int /? nil)
         @--> fun name age -> Printf.sprintf "%s %d" name age)
       ; ((int / int /? nil) @--> fun a b -> Printf.sprintf "%d" (a + b))
       ]
   in
-  Alcotest.(check (option string))
-    "Adding a list of routes works as well"
-    (Some "5")
-    (match' router ~target:"/2/3");
-  Alcotest.(check (option string))
-    "Adding a list of routes works as well"
-    (Some "john 12")
-    (match' router ~target:"/user/john/12")
+  ensure_string_match ~target:"/2/3" router;
+  [%expect {| Exact match with result = 5 |}];
+  ensure_string_match ~target:"/user/john/12" router;
+  [%expect {| Exact match with result = john 12 |}]
 ;;
 
-let test_union_routes () =
+let%expect_test "test union of routers" =
   let open Routes in
-  let union_law nb t rs1 rs2 targets =
-    let router_of_list routers = List.fold_right add_route routers (one_of []) in
+  let union_law nb rs1 rs2 targets =
+    let router_of_list routers = List.fold_right ~f:add_route routers ~init:(one_of []) in
     let router1 = router_of_list (rs1 @ rs2) in
     let router2 = union (router_of_list rs1) (router_of_list rs2) in
-    Alcotest.(check (list (option t)))
-      (Printf.sprintf "union law %d" nb)
-      (List.map (fun target -> match' router1 ~target) targets)
-      (List.map (fun target -> match' router2 ~target) targets)
+    let left = List.map targets ~f:(fun target -> ensure_string_match' router1 ~target) in
+    let right =
+      List.map targets ~f:(fun target -> ensure_string_match' router2 ~target)
+    in
+    let equal = List.equal (Option.equal String.equal) left right in
+    print_endline
+      (if equal
+      then Printf.sprintf "Union law %d - %b" nb equal
+      else Printf.sprintf "Union law %d - %b" nb equal)
   in
-  let r1 = (s "foo" / int /? nil) @--> fun i -> i in
-  let r2 = (s "bar" / int /? nil) @--> fun i -> i in
-  let r3 = (s "foo" / int / s "bar" / int /? nil) @--> fun i j -> i + j in
-  let r4 = (s "bar" / s "baz" /? nil) @--> 0 in
+  let r1 = (s "foo" / int /? nil) @--> fun i -> Int.to_string i in
+  let r2 = (s "bar" / int /? nil) @--> fun i -> Int.to_string i in
+  let r3 = (s "foo" / int / s "bar" / int /? nil) @--> fun i j -> Int.to_string (i + j) in
+  let r4 = (s "bar" / s "baz" /? nil) @--> "0" in
   let targets = [ "foo/10"; "bar/20"; "foo/10/bar/20"; "bar/baz"; "baz" ] in
-  union_law 1 Alcotest.int [ r1 ] [] targets;
-  union_law 2 Alcotest.int [] [ r1 ] targets;
-  union_law 3 Alcotest.int [ r1 ] [ r2 ] targets;
-  union_law 4 Alcotest.int [ r1; r2 ] [ r3; r4 ] targets;
-  union_law 5 Alcotest.int [ r3; r4 ] [ r1; r2 ] targets
+  union_law 1 [ r1 ] [] targets;
+  union_law 2 [] [ r1 ] targets;
+  union_law 3 [ r1 ] [ r2 ] targets;
+  union_law 4 [ r1; r2 ] [ r3; r4 ] targets;
+  union_law 5 [ r3; r4 ] [ r1; r2 ] targets;
+  [%expect
+    {|
+    Union law 1 - true
+    Union law 2 - true
+    Union law 3 - true
+    Union law 4 - true
+    Union law 5 - true |}]
 ;;
 
-let test_left_bias_union () =
+let%expect_test "test left biased union" =
   let open Routes in
-  let r1 = one_of [ ((s "foo" / int /? nil) @--> fun i -> i) ] in
-  let r2 = one_of [ ((s "foo" / int /? nil) @--> fun i -> -i) ] in
-  Alcotest.(check (option int))
-    "A union matches the left routes in preference to the right"
-    (Some 10)
-    (match' (union r1 r2) ~target:"foo/10")
+  let r1 = one_of [ ((s "foo" / int /? nil) @--> fun i -> Int.to_string i) ] in
+  let r2 = one_of [ ((s "foo" / int /? nil) @--> fun i -> Int.to_string (-i)) ] in
+  let router = union r1 r2 in
+  ensure_string_match ~target:"foo/10" router;
+  [%expect {| Exact match with result = 10 |}]
 ;;
 
-let test_map () =
+let%expect_test "test map" =
   let open Routes in
-  let map_option f = function
-    | None -> None
-    | Some x -> Some (f x)
+  let route = (s "foo" / int /? nil) @--> fun i -> i in
+  let option_map_with_int_result =
+    Option.map
+      ~f:Int.to_string
+      (match match' (one_of [ route ]) ~target:"foo/5" with
+      | FullMatch x -> Some x
+      | Match { result; _ } -> Some result
+      | NotFound -> None)
   in
-  let map_law t f r target =
-    Alcotest.(
-      check
-        (option t)
-        "Mapping a function over a route applies that function to the handler"
-        (map_option f (match' (one_of [ r ]) ~target))
-        (match' (one_of [ map f r ]) ~target))
+  let route_map =
+    match match' (one_of [ map Int.to_string route ]) ~target:"foo/5" with
+    | Routes.FullMatch x -> Some x
+    | Match { result; _ } -> Some result
+    | NotFound -> None
   in
-  let r = (s "foo" / int /? nil) @--> fun i -> i in
-  map_law Alcotest.string string_of_int r "foo/5"
+  printf
+    "Routes.map f === Monad.map on the result of the route match = %b\n"
+    (Option.equal String.equal option_map_with_int_result route_map);
+  [%expect {| Routes.map f === Monad.map on the result of the route match = true |}]
 ;;
 
-let test_extractors () =
+let%expect_test "test extractors" =
   let open Routes in
   let router =
     one_of
@@ -105,90 +144,78 @@ let test_extractors () =
         @--> fun a b -> Printf.sprintf "%d-%s" a (Routes.Parts.wildcard_match b))
       ]
   in
-  Alcotest.(check (option string))
-    "Can extract a string and an integer"
-    (Some "Movie")
-    (match' ~target:"foo/Movie" router);
-  Alcotest.(check (option string))
-    "Can extract multiple path parameters"
-    (Some "1-2-3")
-    (match' ~target:"/numbers/1/2/3" router);
-  Alcotest.(check (option string))
-    "Can extract empty wildcard"
-    (Some "")
-    (match' ~target:"/bar" router);
-  Alcotest.(check (option string))
-    "Can extract non-empty wildcard"
-    (Some "/a")
-    (match' ~target:"/bar/a" router);
-  Alcotest.(check (option string))
-    "Can extract non-empty wildcard ending with a slash"
-    (Some "/a/")
-    (match' ~target:"/bar/a/" router);
-  Alcotest.(check (option string))
-    "Can extract non-empty wildcard with slash in the middle"
-    (Some "/a/b")
-    (match' ~target:"/bar/a/b" router);
-  Alcotest.(check (option string))
-    "Can extract both int and wildcard"
-    (Some "42-/x/y/z/")
-    (match' ~target:"/baz/42/and/x/y/z/" router)
+  ensure_string_match ~target:"foo/Movie" router;
+  [%expect {| Exact match with result = Movie |}];
+  ensure_string_match ~target:"/numbers/1/2/3" router;
+  [%expect {| Exact match with result = 1-2-3 |}];
+  ensure_string_match ~target:"/bar" router;
+  [%expect {| Exact match with result = |}];
+  ensure_string_match ~target:"/bar/a" router;
+  [%expect {| Exact match with result = /a |}];
+  ensure_string_match ~target:"/bar/a/" router;
+  [%expect {| Exact match with result = /a/ |}];
+  ensure_string_match ~target:"/bar/a/b" router;
+  [%expect {| Exact match with result = /a/b |}];
+  ensure_string_match ~target:"/baz/42/and/x/y/z/" router;
+  [%expect {| Exact match with result = 42-/x/y/z/ |}]
 ;;
 
-let test_leading_slash_is_discarded () =
+let%expect_test "test leading slash is discarded" =
   let open Routes in
-  let routes = one_of [ (s "foo" /? nil) @--> "foo"; empty @--> "empty" ] in
-  Alcotest.(check (option string))
-    "foo with no leading slash"
-    (Some "foo")
-    (match' routes ~target:"foo");
-  Alcotest.(check (option string))
-    "foo with leading slash"
-    (Some "foo")
-    (match' routes ~target:"/foo");
-  Alcotest.(check (option string))
-    "root with leading slash"
-    (Some "empty")
-    (match' routes ~target:"/");
-  Alcotest.(check (option string))
-    "root with no leading slash"
-    (Some "empty")
-    (match' routes ~target:"")
+  let router = one_of [ (s "foo" /? nil) @--> "foo"; empty @--> "empty" ] in
+  let results =
+    [ ensure_string_match' ~target:"foo" router
+    ; ensure_string_match' ~target:"/foo" router
+    ; ensure_string_match' ~target:"/" router
+    ; ensure_string_match' ~target:"" router
+    ]
+  in
+  printf !"%{sexp: string option list}" results;
+  [%expect
+    {|
+    (("Exact match with result = foo") ("Exact match with result = foo")
+     ("Exact match with result = empty") ("Exact match with result = empty")) |}]
 ;;
 
-let test_verify_first_parsed_route_matches () =
+let%expect_test "verify that first parsed route matches" =
   let open Routes in
   let routes =
     one_of
       [ empty @--> "empty"
-      ; (s "foo" / int /? nil) @--> string_of_int
-      ; (s "foo" / str /? nil) @--> String.uppercase_ascii
-      ; (s "foo" / bool /? nil) @--> string_of_bool
+      ; (s "foo" / int /? nil) @--> Int.to_string_hum
+      ; (s "foo" / str /? nil) @--> String.uppercase
+      ; (s "foo" / bool /? nil) @--> Bool.to_string
       ]
   in
   let routes' =
     one_of
       [ empty @--> "empty"
-      ; ((s "foo" / str /? nil) @--> fun s -> string_of_int (String.length s))
-      ; (s "foo" / int /? nil) @--> string_of_int
-      ; (s "foo" / bool /? nil) @--> string_of_bool
+      ; ((s "foo" / str /? nil) @--> fun s -> Int.to_string_hum (String.length s))
+      ; (s "foo" / int /? nil) @--> Int.to_string_hum
+      ; (s "foo" / bool /? nil) @--> Bool.to_string
       ]
   in
-  Alcotest.(check (option string))
-    "Matches the first route that parses successfully"
-    (Some "121")
-    (match' routes ~target:"/foo/121");
-  Alcotest.(check (option string))
-    "Matches the string route since int match failed"
-    (Some "OCAML")
-    (match' routes ~target:"/foo/ocaml");
-  Alcotest.(check (option string))
-    "Matches the first string route and does not go to the int matcher"
-    (Some "3")
-    (match' routes' ~target:"/foo/451")
+  let results =
+    [ ( "Matches the first route that parses successfully"
+      , ensure_string_match' ~target:"/foo/121" routes )
+    ; ( "Matches the string route since int match failed"
+      , ensure_string_match' ~target:"/foo/ocaml" routes )
+    ; ( "Matches the first string route and does not go to the int matcher"
+      , ensure_string_match' ~target:"/foo/451" routes' )
+    ]
+  in
+  printf !"%{sexp: (string * string option) list}\n" results;
+  [%expect
+    {|
+    (("Matches the first route that parses successfully"
+      ("Exact match with result = 121"))
+     ("Matches the string route since int match failed"
+      ("Exact match with result = OCAML"))
+     ("Matches the first string route and does not go to the int matcher"
+      ("Exact match with result = 3"))) |}]
 ;;
 
-let test_match_routes_with_common_prefix () =
+let%expect_test "match routes with a common prefix" =
   let open Routes in
   let routes =
     one_of
@@ -198,171 +225,21 @@ let test_match_routes_with_common_prefix () =
       ; (s "foo" /? nil) @--> "two"
       ]
   in
-  Alcotest.(check (option string))
-    "Matches empty route"
-    (Some "root")
-    (match' routes ~target:"/");
-  Alcotest.(check (option string))
-    "Matches first overlapping path param"
-    (Some "two")
-    (match' routes ~target:"/foo");
-  Alcotest.(check (option string))
-    "Matches first overlapping path param"
-    (Some "trail")
-    (match' routes ~target:"/foo/bar/");
-  Alcotest.(check (option string))
-    "Matches second overlapping path param"
-    (Some "one")
-    (match' routes ~target:"/foo/bar")
-;;
-
-let test_route_pattern () =
-  let open Routes in
-  let r1 = s "foo" / s "bar" /? nil in
-  let r2 = s "foo" / int / bool /? nil in
-  let r3 = s "foo" / str / bool //? nil in
-  let r4 = s "baz" /? wildcard in
-  let r5 = (s "hello" / s "world" /? nil) @--> "Route" in
-  Alcotest.(check string)
-    "Pretty print empty route"
-    "/"
-    (Format.asprintf "%a" pp_target empty);
-  Alcotest.(check string) "Sprintf empty route" "/" (sprintf empty);
-  Alcotest.(check string)
-    "Pretty print route"
-    "/foo/bar"
-    (Format.asprintf "%a" pp_target r1);
-  Alcotest.(check string)
-    "Pretty print route with pattern"
-    "/foo/:int/:bool"
-    (Format.asprintf "%a" pp_target r2);
-  Alcotest.(check string)
-    "Sprintf route without trailing slash"
-    "/foo/12/true"
-    (sprintf r2 12 true);
-  Alcotest.(check string)
-    "Pretty print route with pattern"
-    "/foo/:string/:bool/"
-    (Format.asprintf "%a" pp_target r3);
-  Alcotest.(check string)
-    "Sprintf route with trailing slash"
-    "/foo/hello/false/"
-    (sprintf r3 "hello" false);
-  Alcotest.(check string)
-    "Pretty print route"
-    "/baz/:wildcard"
-    (Format.asprintf "%a" pp_target r4);
-  Alcotest.(check string)
-    "Pretty print route"
-    "/hello/world"
-    (Format.asprintf "%a" pp_route r5)
-;;
-
-type shape =
-  | Circle
-  | Square
-
-let shape_of_string = function
-  | "Circle" | "circle" -> Some Circle
-  | "Square" | "square" -> Some Square
-  | _ -> None
-;;
-
-let shape_to_string = function
-  | Circle -> "circle"
-  | Square -> "square"
-;;
-
-let test_custom_pattern () =
-  let open Routes in
-  let shape = pattern shape_to_string shape_of_string ":shape" in
-  let shape' = custom ~serialize:shape_to_string ~parse:shape_of_string ~label:":shape" in
-  let r1 () =
-    (s "foo" / int / s "shape" / shape' /? nil)
-    @--> fun c shape -> Printf.sprintf "%d - %s" c (shape_to_string shape)
-  in
-  let r2 () = s "shape" / shape / s "create" /? nil in
-  let router = one_of [ r1 () ] in
-  Alcotest.(check (option string))
-    "Can match a custom pattern"
-    (Some "12 - circle")
-    (match' router ~target:"/foo/12/shape/Circle");
-  Alcotest.(check (option string))
-    "Invalid shape does not match"
-    None
-    (match' router ~target:"/foo/12/shape/rectangle");
-  Alcotest.(check string)
-    "Can pretty print custom pattern"
-    "/foo/:int/shape/:shape"
-    (Format.asprintf "%a" pp_route (r1 ()));
-  Alcotest.(check string)
-    "Can serialize route with custom params"
-    "/shape/square/create"
-    (sprintf (r2 ()) Square)
-;;
-
-let test_matcher_discards_query_params () =
-  let open Routes in
-  let routes = one_of [ ((s "foo" / str /? nil) @--> fun x -> x); empty @--> "root" ] in
-  Alcotest.(check (option string))
-    "Discards query params"
-    (Some "hello")
-    (match' routes ~target:"/foo/hello?baz=bar");
-  Alcotest.(check (option string))
-    "Discards query params"
-    (Some "root")
-    (match' routes ~target:"?baz=bar")
-;;
-
-let test_prefixing_targets () =
-  let open Routes in
-  let add_route path1 path2 handler (routes1, routes2) =
-    let routes1 =
-      routes1
-      |> add_route ((path1 / path2 /? nil) @--> handler)
-      |> add_route ((path1 / path2 //? nil) @--> handler)
-    in
-    let routes2 =
-      routes2
-      |> add_route ((path1 /~ (path2 /? nil)) @--> handler)
-      |> add_route ((path1 /~ (path2 //? nil)) @--> handler)
-    in
-    routes1, routes2
-  in
-  let check_target nb t (routes1, routes2) target =
-    Alcotest.(check (option t))
-      (Printf.sprintf "prefix test %d" nb)
-      (match' routes1 ~target)
-      (match' routes2 ~target)
-  in
-  let routes =
-    (one_of [], one_of [])
-    |> add_route (s "foo") (s "bar") 10
-    |> add_route (s "foo") int (fun n -> n)
-  in
-  check_target 1 Alcotest.int routes "foo/bar";
-  check_target 2 Alcotest.int routes "foo/bar/10";
-  check_target 3 Alcotest.int routes "foo/10"
-;;
-
-let () =
-  let tests =
-    [ "Empty router has no match", `Quick, test_no_match
-    ; "Can extract path parameters", `Quick, test_extractors
-    ; "Leading slash is discarded", `Quick, test_leading_slash_is_discarded
-    ; ( "Responds with the first successful match"
-      , `Quick
-      , test_verify_first_parsed_route_matches )
-    ; "Matches routes with common prefix", `Quick, test_match_routes_with_common_prefix
-    ; "Pretty print route", `Quick, test_route_pattern
-    ; "Can work with custom patterns", `Quick, test_custom_pattern
-    ; "Discards query params", `Quick, test_matcher_discards_query_params
-    ; "Can add a route", `Quick, test_add_route
-    ; "Union of routers is lawful", `Quick, test_union_routes
-    ; "Unions are left-biased", `Quick, test_left_bias_union
-    ; "Maps are lawful", `Quick, test_map
-    ; "Paths can be prefixed to targets", `Quick, test_prefixing_targets
+  let results =
+    [ "Matches empty route", ensure_string_match' ~target:"/" routes
+    ; "Matches first overlapping path param", ensure_string_match' ~target:"/foo" routes
+    ; ( "Matches first overlapping path param"
+      , ensure_string_match' ~target:"/foo/bar/" routes )
+    ; ( "Matches first overlapping path param"
+      , ensure_string_match' ~target:"/foo/bar" routes )
     ]
   in
-  Alcotest.run "Tests" [ "Routes tests", tests ]
+  printf !"%{sexp: (string * string option) list}\n" results;
+  [%expect
+    {|
+    (("Matches empty route" ("Exact match with result = root"))
+     ("Matches first overlapping path param" ("Exact match with result = two"))
+     ("Matches first overlapping path param"
+      ("Not exact match, but found a match without a trailing slash with result = one"))
+     ("Matches first overlapping path param" ("Exact match with result = one"))) |}]
 ;;

--- a/test/routing_test.ml
+++ b/test/routing_test.ml
@@ -4,14 +4,14 @@ open! Stdio
 let ensure_empty ~target ~msg router =
   let open Routes in
   match match' ~target router with
-  | Routes.NotFound -> print_endline msg
+  | Routes.NotFound -> printf "%s\n" msg
   | _ -> assert false
 ;;
 
 let ensure_string_match ~target router =
   let open Routes in
   match match' ~target router with
-  | Routes.NotFound -> print_endline "No route matched"
+  | Routes.NotFound -> printf "%s\n" "No route matched"
   | FullMatch r -> printf "Exact match with result = %s\n" r
   | Match { with_trailing_slash; result } ->
     printf
@@ -76,7 +76,7 @@ let%expect_test "test union of routers" =
       List.map targets ~f:(fun target -> ensure_string_match' router2 ~target)
     in
     let equal = List.equal (Option.equal String.equal) left right in
-    print_endline
+    printf "%s\n"
       (if equal
       then Printf.sprintf "Union law %d - %b" nb equal
       else Printf.sprintf "Union law %d - %b" nb equal)


### PR DESCRIPTION
Simplify adding routes that need to work with both trailing slashes and without. `/?` and `//?` in addition to performing exact matches, will also match routes if the only difference in the target is the presence or absence of trailing slash. The new type used to indicate match results will inform the user if the match was an exact match, or if it matched because of the new behavior around trailing slashes.

Relates to #50 