### PR TITLE
opam: add core* deps

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -26,6 +26,8 @@
    (>= 4.08.0))
   (base :with-test)
   (stdio :with-test)
+  (core_bench :with-test)
+  (core_unix :with-test)
   (ppx_expect :with-test)
   (ppx_sexp_conv :with-test)
   (ppx_sexp_value :with-test)

--- a/routes.opam
+++ b/routes.opam
@@ -15,6 +15,8 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "base" {with-test}
   "stdio" {with-test}
+  "core_bench" {with-test}
+  "core_unix" {with-test}
   "ppx_expect" {with-test}
   "ppx_sexp_conv" {with-test}
   "ppx_sexp_value" {with-test}


### PR DESCRIPTION
A couple of JS libs are used in bench but were not part of the opam file.