### PR TITLE
Support melange

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,8 +1,10 @@
-(lang dune 2.9)
+(lang dune 3.8)
 
 (name routes)
 
 (using mdx 0.1)
+
+(using melange 0.1)
 
 (generate_opam_files true)
 

--- a/routes.opam
+++ b/routes.opam
@@ -13,6 +13,7 @@ bug-reports: "https://github.com/anuragsoni/routes/issues"
 depends: [
   "dune" {>= "2.9"}
   "ocaml" {>= "4.08.0"}
+  "melange" {> "0.3.2"}
   "base" {with-test}
   "stdio" {with-test}
   "ppx_expect" {with-test}

--- a/src/dune
+++ b/src/dune
@@ -1,2 +1,3 @@
 (library
+ (modes :standard melange)
  (public_name routes))


### PR DESCRIPTION
Adds `melange` as a dependency, and changes the library mode to include `melange` as well.

There is one downside: users of `routes` will have to download `melange` as a dependency, even if they only use the native version (see related https://github.com/ocaml/dune/issues/7939).

Hopefully this is not a blocker, but the PR can be put on hold. I am happy to explore other paths if it's a blocker (e.g. publish 2 versions of the libraries, one "native-only" and one "universal").